### PR TITLE
Temporary fixes for github pages

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -7,7 +7,7 @@ import TheStoriesView from "@/views/TheStoriesView";
 import TheTourView from "@/views/TheTourView";
 
 export default new VueRouter({
-  mode: "history",
+//  mode: "history",
   routes: [
     { name: "home", path: "/", redirect: "/tour" },
     { name: "about", path: "/about", component: TheAboutView },

--- a/src/util/mapSupport.js
+++ b/src/util/mapSupport.js
@@ -15,23 +15,23 @@ class MapSupport {
    * @return {String} Mapbox style URL.
    */
   getBaseMap() {
-    if (process.env.NODE_ENV == "development") {
-      return {
-        version: 8,
-        sources: {},
-        layers: [
-            {
-            id: "background",
-            type: "background",
-            paint: {
-              "background-color": "rgb(255, 246, 242)"
-            }
+    // if (process.env.NODE_ENV == "development") {
+    return {
+      version: 8,
+      sources: {},
+      layers: [
+          {
+          id: "background",
+          type: "background",
+          paint: {
+            "background-color": "rgb(255, 246, 242)"
           }
-        ]
-      };
-    } else {
-      return process.env.VUE_APP_MAPBOX_STYLE_URL;
-    }
+        }
+      ]
+    };
+    // } else {
+    //   return process.env.VUE_APP_MAPBOX_STYLE_URL;
+    // }
   }
 
   /**

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,6 @@
 const path = require("path");
 module.exports = {
+  publicPath: "/span-mapp",
   pluginOptions: {
     "style-resources-loader": {
       preProcessor: "scss",


### PR DESCRIPTION
- Disable history mode for router
  - Github pages only works from the index.html file, so we have to use the default hash mode.
- Ignore VUE_APP_MAPBOX_STYLE_URL and use default style for development mode
  - I just don't know what this is supposed to be. If you do you don't have to merge this change.
- Change publicPath to /span-mapp
  - The github pages site is on the /span-mapp path.
- Rename jsonColumnArrayQuery.js to JsonColumnArrayQuery.js
  - The name of the file and its import from another file were inconsistent. I had to make the capitalization consistent in order to fix build errors.